### PR TITLE
chore(#50): submodule bump for Tier-3 pose-math removal + close-out doc

### DIFF
--- a/docs/audit-dead-code-issue50.md
+++ b/docs/audit-dead-code-issue50.md
@@ -77,10 +77,12 @@ and `arglCameraViewRHf(cv::Mat)` overloads, `webarkitGetVersion(char**)` + the
 `WEBARKIT_HEADER_VERSION_MAJOR/MINOR/TINY/DEV` constants, `N`, `featureDetectPyramidLevel`,
 and `grayscale()` — kept as plausible public API / OCVConfig parity.
 
-### Pending decision
+### Removed — webarkit/WebARKitLib#58 (Tier 3)
 - `computePose` / `invertPose` / `computeGLviewMatrix()` (no-arg) — WebARKit's own
-  pose math, superseded by `cameraPoseFromPoints` + the #55 `pose3d` fix. Not yet
-  removed; awaiting a keep/remove call.
+  pose math, superseded by `cameraPoseFromPoints` + the #55 `pose3d` fix. Removed
+  (behavior-neutral; the live `cameraPoseFromPoints` → `getTrackablePose` →
+  `updateTrackable` → `computeGLviewMatrix(cv::Mat&)` path is unchanged). With this,
+  the #50 audit is complete — every remaining flagged symbol was decided KEEP.
 
 ---
 


### PR DESCRIPTION
Companion to webarkit/WebARKitLib#58 (Tier-3: remove superseded `computePose`/`invertPose`/`computeGLviewMatrix()`-noarg).

## What
- **Submodule bump** to the Tier-3 removal commit.
- **`docs/audit-dead-code-issue50.md`**: move the `computePose` cluster from "pending" to "removed (#58)" — the #50 audit is now **complete** (every other flagged symbol was decided KEEP).

## No `build/`/`dist/` change
The removed functions were already unreferenced and dead-code-eliminated by the linker, so the emscripten output is byte-identical to `dev` — verified `git diff dev -- build/ dist/` is empty. (Rebuilt and tested anyway: static example tracks, pyrLevel 1, 1000 matches; behavior-neutral, live pose path unchanged.)

## Status
After this merges, **#50 can be closed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)